### PR TITLE
Fix panel border color

### DIFF
--- a/themes/Noir-Poimandres-theme.json
+++ b/themes/Noir-Poimandres-theme.json
@@ -112,7 +112,7 @@
     "inputValidation.warningBorder": "#fffac2",
     "notifications.background": "#1b1e28",
     "notifications.foreground": "#e4f0fb",
-    "panel.border": "#00000",
+    "panel.border": "#1b1e28",
     "panelTitle.activeForeground": "#a6accd",
     "peekView.border": "#00000030",
     "peekViewEditor.background": "#a6accd05",


### PR DESCRIPTION
Hi thank you for the theme! I noticed in the latest update, when using poimandres, the panel border appears bright red.

Before:
<img width="1512" alt="Screenshot 2023-10-26 at 10 02 38 PM" src="https://github.com/andrew-george/Noir-vscode-theme/assets/17835438/bd9669ec-5568-4e76-9b46-92e1eafad910">


After:
<img width="1624" alt="Screenshot 2023-10-26 at 10 03 18 PM" src="https://github.com/andrew-george/Noir-vscode-theme/assets/17835438/84651a22-d206-4285-a1d8-3efdb33857d3">
