### PR TITLE
Update Noir-Poimandres-Black-theme.json to have better background col…

### DIFF
--- a/themes/Noir-Poimandres-Black-theme.json
+++ b/themes/Noir-Poimandres-Black-theme.json
@@ -136,7 +136,7 @@
 		"statusBar.background": "#000",
 		"statusBar.foreground": "#a6accd",
 		"statusBar.noFolderBackground": "#000",
-		"tab.activeBackground": "#000",
+		"tab.activeBackground": "#191919",
 		"tab.activeForeground": "#e4f0fb",
 		"tab.border": "#00000000",
 		"tab.inactiveBackground": "#000",


### PR DESCRIPTION
…or for active tab

Currently, the Noir-Poimandres-Black-theme.json theme has #000 as the value for the active tab. But, that does not offer the best experience because of the whole ui has the same background color. If you have multiple files opened at the same time, it is gonna take you some time to figure out which file is currently opened or not. It would be a lot better to give active tab a slightly different background color so that it is clearly visible